### PR TITLE
Standardize role label to 'Software Developer 1' and add NIT Calicut link

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,7 +7,7 @@ import { buildPageMetadata } from '../lib/seo'
 export const metadata: Metadata = buildPageMetadata({
   title: 'About | Frontend Developer',
   description:
-    'Learn about Thulunga Basumatary, a Software Developer I focused on Angular, TypeScript, enterprise frontend systems, and scalable product engineering.',
+    'Learn about Thulunga Basumatary, a Software Developer 1 focused on Angular, TypeScript, enterprise frontend systems, and scalable product engineering.',
   path: '/about',
   keywords: ['about frontend developer', 'software engineer profile', 'angular developer background'],
 })

--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import Image from 'next/image'
+import Link from 'next/link'
 
 export function About() {
   const stats = [
@@ -50,7 +51,13 @@ export function About() {
             <div className="pt-2 sm:pt-4 space-y-2 sm:space-y-3">
               <div className="flex items-start gap-2 text-dark-700 dark:text-dark-200 text-sm sm:text-base">
                 <span className="text-blue-500 font-bold flex-shrink-0">✓</span>
-                <span><strong>B.Tech Computer Science</strong> - NIT Calicut (Graduated 2022)</span>
+                <span>
+                  <strong>B.Tech Computer Science</strong> -{' '}
+                  <Link href="https://nitc.ac.in" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">
+                    NIT Calicut
+                  </Link>{' '}
+                  (Graduated 2022)
+                </span>
               </div>
               <div className="flex items-start gap-2 text-dark-700 dark:text-dark-200 text-sm sm:text-base">
                 <span className="text-blue-500 font-bold flex-shrink-0">✓</span>
@@ -98,7 +105,7 @@ export function About() {
               className="bg-gradient-to-br from-blue-500 to-purple-600 p-4 sm:p-6 rounded-xl text-white"
             >
               <h3 className="font-bold text-base sm:text-lg mb-2">Current Role</h3>
-              <p className="text-blue-100 text-sm sm:text-base">Software Developer I at SOTI Inc. • Gurgaon, India</p>
+              <p className="text-blue-100 text-sm sm:text-base">Software Developer 1 at SOTI Inc. • Gurgaon, India</p>
               <p className="text-blue-100 text-xs sm:text-sm mt-2">Since July 2024</p>
             </motion.div>
           </motion.div>

--- a/app/components/Achievements.tsx
+++ b/app/components/Achievements.tsx
@@ -15,7 +15,7 @@ export function Achievements() {
     {
       icon: '📈',
       title: 'Promoted Ahead of Cycle',
-      detail: 'Associate Developer to Software Developer I',
+      detail: 'Associate Developer to Software Developer 1',
       description: 'Promoted ahead of the standard cycle at SOTI Inc., reflecting consistent high performance and expanded ownership of component architecture.',
       color: 'from-green-400 to-emerald-500',
     },

--- a/app/components/Experience.tsx
+++ b/app/components/Experience.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion'
 export function Experience() {
   const experiences = [
     {
-      title: 'Software Developer I',
+      title: 'Software Developer 1',
       company: 'SOTI Inc.',
       location: 'Gurgaon, India',
       period: 'July 2024 - Present',
@@ -26,7 +26,7 @@ export function Experience() {
       highlights: [
         'Delivered 10+ reusable Angular UI components adopted across multiple enterprise modules',
         'Resolved high-priority UI bugs and performance regressions',
-        'Grew into component design ownership ahead of promotion to Software Developer I',
+        'Grew into component design ownership ahead of promotion to Software Developer 1',
         'Collaborated with cross-functional teams on feature delivery and code reviews',
       ],
     },

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -56,7 +56,7 @@ export function Footer() {
               </div>
               <span className="text-lg sm:text-xl font-bold">Thulunga</span>
             </div>
-            <p className="text-gray-400 text-xs sm:text-sm">Software Developer I | Angular & TypeScript Specialist</p>
+            <p className="text-gray-400 text-xs sm:text-sm">Software Developer 1 | Angular & TypeScript Specialist</p>
           </motion.div>
 
           {/* Quick Links */}

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -53,7 +53,7 @@ export function Hero() {
 
             <motion.div variants={itemVariants}>
               <h2 className="text-lg sm:text-xl md:text-2xl text-blue-600 dark:text-blue-400 font-semibold leading-snug">
-                Software Developer I | Angular & TypeScript Specialist
+                Software Developer 1 | Angular & TypeScript Specialist
               </h2>
             </motion.div>
 

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -5,7 +5,7 @@ import { PageScaffold } from '../components/PageScaffold'
 import { buildPageMetadata } from '../lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Experience | Software Developer I',
+  title: 'Experience | Software Developer 1',
   description:
     'Professional experience of Thulunga Basumatary at SOTI Inc. including Angular architecture, performance optimization, and enterprise product delivery.',
   path: '/experience',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     template: '%s | Thulunga Basumatary',
   },
   description:
-    'Software Developer Portfolio of Thulunga Basumatary - Software Developer I at SOTI Inc. specializing in Angular, TypeScript, React, and enterprise frontend engineering.',
+    'Software Developer Portfolio of Thulunga Basumatary - Software Developer 1 at SOTI Inc. specializing in Angular, TypeScript, React, and enterprise frontend engineering.',
   keywords: [
     'software developer portfolio',
     'frontend developer portfolio',
@@ -61,7 +61,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Thulunga Basumatary | Software Developer Portfolio',
     description:
-      'Software Developer I portfolio with Angular, TypeScript, and full-stack project highlights.',
+      'Software Developer 1 portfolio with Angular, TypeScript, and full-stack project highlights.',
     creator: '@Thulunga',
     images: [siteConfig.defaultOgImage],
   },

--- a/app/lib/seo.ts
+++ b/app/lib/seo.ts
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 export const siteConfig = {
   siteName: 'Thulunga Basumatary Portfolio',
   author: 'Thulunga Basumatary',
-  role: 'Software Developer I',
+  role: 'Software Developer 1',
   siteUrl: 'https://thulunga.vercel.app',
   location: 'Gurgaon, India',
   email: 'thulunga.tb@gmail.com',
@@ -130,7 +130,7 @@ export const faqItems = [
   {
     question: 'Who is Thulunga Basumatary?',
     answer:
-      'Thulunga Basumatary is a Software Developer I at SOTI Inc. specializing in Angular, TypeScript, and enterprise frontend architecture.',
+      'Thulunga Basumatary is a Software Developer 1 at SOTI Inc. specializing in Angular, TypeScript, and enterprise frontend architecture.',
   },
   {
     question: 'What technologies does this frontend developer use?',


### PR DESCRIPTION
### Motivation
- Standardize the job-level label across the site by changing "Software Developer I" to "Software Developer 1" for consistent copy and metadata.
- Improve the About page UX by linking the institution name to its official site.
- Keep SEO content and JSON-LD aligned with the updated role terminology.

### Description
- Replaced occurrences of the role label from `Software Developer I` to `Software Developer 1` in site metadata and visible UI text across `app/layout.tsx`, `app/lib/seo.ts`, `app/components/Hero.tsx`, `app/components/Footer.tsx`, `app/components/About.tsx`, `app/components/Achievements.tsx`, `app/components/Experience.tsx`, `app/experience/page.tsx`, and `app/about/page.tsx`.
- Added an external anchor to NIT Calicut in `app/components/About.tsx` and imported `Link` from `next/link` to render the linked institution name.
- Minor text adjustments in the About stats and Current Role card to reflect the normalized label and maintain consistent phrasing.

### Testing
- Ran `npm run build` to validate the Next.js production build and it completed successfully.
- Ran `npm run typecheck` to ensure TypeScript correctness and there were no type errors.
- Ran `npm run lint` to verify formatting and lint rules and there were no lint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5aea8796483279b30e7db8f5cc57b)